### PR TITLE
extract single selector default expand state as config

### DIFF
--- a/lib/SingleSelector/index.js
+++ b/lib/SingleSelector/index.js
@@ -58,7 +58,7 @@ var SingleSelector = function (_Component) {
 
     var _this = _possibleConstructorReturn(this, (SingleSelector.__proto__ || Object.getPrototypeOf(SingleSelector)).call(this, props));
 
-    _this.state = { expanded: false };
+    _this.state = { expanded: props.expanded };
 
     _this.radioColumn = {
       name: 'radio',
@@ -147,12 +147,12 @@ var SingleSelector = function (_Component) {
   }, {
     key: 'render',
     value: function render() {
-      var _props$dataTableProps = this.props.dataTableProps;
-      var columns = _props$dataTableProps.columns;
-      var onQueryChange = _props$dataTableProps.onQueryChange;
-      var dataSource = _props$dataTableProps.dataSource;
-      var total = _props$dataTableProps.total;
-      var emptyText = _props$dataTableProps.emptyText;
+      var _props$dataTableProps = this.props.dataTableProps,
+          columns = _props$dataTableProps.columns,
+          onQueryChange = _props$dataTableProps.onQueryChange,
+          dataSource = _props$dataTableProps.dataSource,
+          total = _props$dataTableProps.total,
+          emptyText = _props$dataTableProps.emptyText;
       var order = this.props.dataTableProps.query.order;
 
       var tableColumns = [this.radioColumn].concat(columns);
@@ -215,6 +215,7 @@ var SingleSelector = function (_Component) {
 
 SingleSelector.propTypes = {
   warpperClassName: _react.PropTypes.string,
+  expanded: _react.PropTypes.bool,
   disabled: _react.PropTypes.bool,
   selectedId: _react.PropTypes.oneOfType([_react.PropTypes.string, _react.PropTypes.number]),
   onChange: _react.PropTypes.func.isRequired,
@@ -240,6 +241,7 @@ SingleSelector.propTypes = {
 
 SingleSelector.defaultProps = {
   warpperClassName: 'form-width-md',
+  expanded: false,
   disabled: false,
   filterByState: false,
   stateItems: [{ key: '0,1', value: 'All' }, { key: '0', value: 'Active' }, { key: '1', value: 'Inactive' }]

--- a/src/SingleSelector/index.js
+++ b/src/SingleSelector/index.js
@@ -12,7 +12,7 @@ class SingleSelector extends Component {
   constructor(props) {
     super(props);
 
-    this.state = { expanded: false };
+    this.state = { expanded: props.expanded };
 
     this.radioColumn = {
       name: 'radio',
@@ -130,6 +130,7 @@ class SingleSelector extends Component {
 
 SingleSelector.propTypes = {
   warpperClassName: PropTypes.string,
+  expanded: PropTypes.bool,
   disabled: PropTypes.bool,
   selectedId: PropTypes.oneOfType([
     PropTypes.string,
@@ -158,6 +159,7 @@ SingleSelector.propTypes = {
 
 SingleSelector.defaultProps = {
   warpperClassName: 'form-width-md',
+  expanded: false,
   disabled: false,
   filterByState: false,
   stateItems: [


### PR DESCRIPTION
This change has extracted SingleSelector expanded state out as props.
Its default is set to `false` to align with existing implementation.